### PR TITLE
Fix hydration mismatch due to random mock data

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -8,9 +8,14 @@ export interface AnalyticsRecord {
 export const records: AnalyticsRecord[] = Array.from({ length: 30 }).map((_, i) => {
   const date = new Date();
   date.setDate(date.getDate() - (29 - i));
-  const users = Math.floor(200 + Math.random() * 300);
-  const conversions = Math.floor(users * (0.05 + Math.random() * 0.1));
-  const revenue = conversions * (20 + Math.random() * 80);
+
+  // Generate deterministic values based only on the index so that the
+  // initial data is identical during server and client rendering. This
+  // avoids hydration mismatches caused by Math.random().
+  const users = 200 + ((i * 17) % 300);
+  const conversions = Math.floor(users * (0.05 + ((i % 10) / 100)));
+  const revenue = conversions * (20 + ((i * 23) % 80));
+
   return {
     date: date.toISOString().slice(0, 10),
     revenue: Math.round(revenue),


### PR DESCRIPTION
## Summary
- remove `Math.random()` usage from the mock data generator
- generate deterministic values to ensure server and client renders match

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889b2fb9b248324842e96b19e2377e1