### PR TITLE
Add chart scales and interactive pie slices

### DIFF
--- a/src/components/BarChart.tsx
+++ b/src/components/BarChart.tsx
@@ -5,10 +5,46 @@ interface BarChartProps {
 }
 
 export default function BarChart({ data, width = 300, height = 150 }: BarChartProps) {
+  const axisPadding = 20;
   const max = Math.max(...data);
   const barWidth = width / data.length;
+  const yTicks = 5;
+  const xTickInterval = Math.max(1, Math.floor(data.length / 5));
+
   return (
-    <svg width={width} height={height} className="w-full">
+    <svg width={width} height={height + axisPadding} className="w-full">
+      {/* axes */}
+      <line x1={0} y1={height} x2={width} y2={height} stroke="currentColor" strokeWidth={1} />
+      <line x1={0} y1={0} x2={0} y2={height} stroke="currentColor" strokeWidth={1} />
+
+      {/* Y axis ticks */}
+      {Array.from({ length: yTicks }).map((_, i) => {
+        const value = (max / (yTicks - 1)) * i;
+        const y = height - (value / max) * height;
+        return (
+          <text
+            key={i}
+            x={-4}
+            y={y + 4}
+            fontSize={10}
+            textAnchor="end"
+          >
+            {Math.round(value)}
+          </text>
+        );
+      })}
+
+      {/* X axis ticks */}
+      {data.map((_, i) => {
+        if (i % xTickInterval !== 0) return null;
+        const x = i * barWidth + barWidth / 2;
+        return (
+          <text key={i} x={x} y={height + 12} fontSize={10} textAnchor="middle">
+            {i + 1}
+          </text>
+        );
+      })}
+
       {data.map((d, i) => {
         const barHeight = (d / max) * height;
         return (

--- a/src/components/LineChart.tsx
+++ b/src/components/LineChart.tsx
@@ -5,6 +5,7 @@ interface LineChartProps {
 }
 
 export default function LineChart({ data, width = 300, height = 150 }: LineChartProps) {
+  const axisPadding = 20;
   const max = Math.max(...data);
   const points = data
     .map((d, i) => {
@@ -13,12 +14,49 @@ export default function LineChart({ data, width = 300, height = 150 }: LineChart
       return `${x},${y}`;
     })
     .join(' ');
+
+  const yTicks = 5;
+  const xTickInterval = Math.max(1, Math.floor((data.length - 1) / 4));
+
   return (
-    <svg width={width} height={height} className="w-full">
+    <svg width={width} height={height + axisPadding} className="w-full">
+      {/* axes */}
+      <line x1={0} y1={height} x2={width} y2={height} stroke="currentColor" strokeWidth={1} />
+      <line x1={0} y1={0} x2={0} y2={height} stroke="currentColor" strokeWidth={1} />
+
+      {/* Y axis ticks */}
+      {Array.from({ length: yTicks }).map((_, i) => {
+        const value = (max / (yTicks - 1)) * i;
+        const y = height - (value / max) * height;
+        return (
+          <text
+            key={i}
+            x={-4}
+            y={y + 4}
+            fontSize={10}
+            textAnchor="end"
+          >
+            {Math.round(value)}
+          </text>
+        );
+      })}
+
+      {/* X axis ticks */}
+      {data.map((_, i) => {
+        if (i % xTickInterval !== 0) return null;
+        const x = (i / (data.length - 1)) * width;
+        return (
+          <text key={i} x={x} y={height + 12} fontSize={10} textAnchor="middle">
+            {i + 1}
+          </text>
+        );
+      })}
+
+      {/* line */}
       <polyline
         fill="none"
         stroke="currentColor"
-        strokeWidth="2"
+        strokeWidth={2}
         points={points}
       />
     </svg>

--- a/src/components/PieChart.tsx
+++ b/src/components/PieChart.tsx
@@ -1,9 +1,12 @@
+import { useState } from 'react';
+
 interface PieChartProps {
   data: { value: number; color: string }[];
   size?: number;
 }
 
 export default function PieChart({ data, size = 150 }: PieChartProps) {
+  const [active, setActive] = useState<number | null>(null);
   const total = data.reduce((sum, d) => sum + d.value, 0);
   let cumulative = 0;
   const slices = data.map((slice, idx) => {
@@ -12,11 +15,41 @@ export default function PieChart({ data, size = 150 }: PieChartProps) {
     const [endX, endY] = getCoordinates(cumulative / total, size);
     const largeArc = slice.value / total > 0.5 ? 1 : 0;
     const pathData = `M ${size} ${size} L ${startX} ${startY} A ${size} ${size} 0 ${largeArc} 1 ${endX} ${endY} Z`;
-    return <path key={idx} d={pathData} fill={slice.color} />;
+    const isActive = active === idx;
+    return (
+      <path
+        key={idx}
+        d={pathData}
+        fill={slice.color}
+        style={{ transformOrigin: 'center', transition: 'transform 0.2s' }}
+        className={isActive ? 'scale-105 opacity-80' : ''}
+        onMouseEnter={() => setActive(idx)}
+        onMouseLeave={() => setActive(null)}
+      />
+    );
   });
+
+  const activeSlice = active !== null ? data[active] : null;
+
   return (
-    <svg width={size * 2} height={size * 2} viewBox={`0 0 ${size * 2} ${size * 2}`} className="w-full">
+    <svg
+      width={size * 2}
+      height={size * 2}
+      viewBox={`0 0 ${size * 2} ${size * 2}`}
+      className="w-full"
+    >
       {slices}
+      {activeSlice && (
+        <text
+          x={size}
+          y={size}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          className="text-xs font-semibold fill-current pointer-events-none"
+        >
+          {((activeSlice.value / total) * 100).toFixed(0)}%
+        </text>
+      )}
     </svg>
   );
 }


### PR DESCRIPTION
## Summary
- show axes with tick marks on `LineChart`
- show axes with tick marks on `BarChart`
- make `PieChart` interactive on hover

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6889b3ca592883248c1065d092124cea