### PR TITLE
Add month/year chart filters

### DIFF
--- a/src/components/BarChart.tsx
+++ b/src/components/BarChart.tsx
@@ -1,10 +1,11 @@
 interface BarChartProps {
   data: number[];
+  labels?: string[];
   width?: number;
   height?: number;
 }
 
-export default function BarChart({ data, width = 300, height = 150 }: BarChartProps) {
+export default function BarChart({ data, labels, width = 300, height = 150 }: BarChartProps) {
   const axisPadding = 20;
   const max = Math.max(...data);
   const barWidth = width / data.length;
@@ -40,7 +41,7 @@ export default function BarChart({ data, width = 300, height = 150 }: BarChartPr
         const x = i * barWidth + barWidth / 2;
         return (
           <text key={i} x={x} y={height + 12} fontSize={10} textAnchor="middle">
-            {i + 1}
+            {labels ? labels[i] : i + 1}
           </text>
         );
       })}

--- a/src/components/LineChart.tsx
+++ b/src/components/LineChart.tsx
@@ -1,10 +1,11 @@
 interface LineChartProps {
   data: number[];
+  labels?: string[];
   width?: number;
   height?: number;
 }
 
-export default function LineChart({ data, width = 300, height = 150 }: LineChartProps) {
+export default function LineChart({ data, labels, width = 300, height = 150 }: LineChartProps) {
   const axisPadding = 20;
   const max = Math.max(...data);
   const points = data
@@ -47,7 +48,7 @@ export default function LineChart({ data, width = 300, height = 150 }: LineChart
         const x = (i / (data.length - 1)) * width;
         return (
           <text key={i} x={x} y={height + 12} fontSize={10} textAnchor="middle">
-            {i + 1}
+            {labels ? labels[i] : i + 1}
           </text>
         );
       })}

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -5,9 +5,9 @@ export interface AnalyticsRecord {
   conversions: number;
 }
 
-export const records: AnalyticsRecord[] = Array.from({ length: 30 }).map((_, i) => {
+export const records: AnalyticsRecord[] = Array.from({ length: 365 }).map((_, i) => {
   const date = new Date();
-  date.setDate(date.getDate() - (29 - i));
+  date.setDate(date.getDate() - (364 - i));
 
   // Generate deterministic values based only on the index so that the
   // initial data is identical during server and client rendering. This


### PR DESCRIPTION
## Summary
- generate data for an entire year
- allow selecting year and month to filter data
- add labels prop to `LineChart` and `BarChart`
- pass computed date labels to charts

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889e36ebb70832493b16ef0c35d0a38