### PR TITLE
Add dark mode toggle button

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,8 +17,14 @@
   }
 }
 
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  transition: background 0.2s, color 0.2s;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,11 +5,10 @@ import LineChart from '../components/LineChart';
 import BarChart from '../components/BarChart';
 import PieChart from '../components/PieChart';
 import DataTable from '../components/DataTable';
-import useDarkMode from '../hooks/useDarkMode';
+import DarkModeToggle from '../components/DarkModeToggle';
 import { records as rawRecords } from '../data/mockData';
 
 export default function Home() {
-  const [dark, setDark] = useDarkMode();
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
   const [year, setYear] = useState('');
@@ -85,12 +84,7 @@ export default function Home() {
     <div className="p-4 sm:p-8 space-y-6">
       <header className="flex justify-between items-center">
         <h1 className="text-2xl font-bold">ADmyBRAND Insights</h1>
-        <button
-          className="px-3 py-1 border rounded"
-          onClick={() => setDark(!dark)}
-        >
-          {dark ? 'Light' : 'Dark'} Mode
-        </button>
+        <DarkModeToggle />
       </header>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
         <MetricCard title="Revenue" value={`$${totals.revenue}`} />

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,18 @@
+'use client';
+import useDarkMode from '../hooks/useDarkMode';
+
+export default function DarkModeToggle() {
+  const [enabled, setEnabled] = useDarkMode();
+
+  return (
+    <button
+      onClick={() => setEnabled(!enabled)}
+      aria-label="Toggle dark mode"
+      className={`relative inline-flex h-6 w-12 items-center rounded-full p-1 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${enabled ? 'bg-blue-600' : 'bg-gray-300'}`}
+    >
+      <span
+        className={`h-4 w-4 transform rounded-full bg-white shadow transition-transform ${enabled ? 'translate-x-6' : ''}`}
+      />
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `DarkModeToggle` component with styles
- swap old dark mode button for new toggle
- improve global styles for dark mode support

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889e5d9030c8324a1433d3f1ec5ab72