### PR TITLE
Improve theme toggle

### DIFF
--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -2,17 +2,14 @@
 import { useEffect, useState } from "react";
 
 export default function useDarkMode() {
-  const [enabled, setEnabled] = useState(false);
-
-  // Load stored theme or system preference
-  useEffect(() => {
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof window === "undefined") return false;
     const savedTheme = localStorage.getItem("theme");
     if (savedTheme) {
-      setEnabled(savedTheme === "dark");
-    } else {
-      setEnabled(window.matchMedia("(prefers-color-scheme: dark)").matches);
+      return savedTheme === "dark";
     }
-  }, []);
+    return window.matchMedia("(prefers-color-scheme: dark)").matches;
+  });
 
   // Apply dark mode to the <html> tag for full-page effect
   useEffect(() => {


### PR DESCRIPTION
## Summary
- prevent flash of light mode by initializing dark mode state from storage

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a09a924448324906f3d336fc81fac