### PR TITLE
Add light class to ensure theme toggles properly

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,6 +36,15 @@
   --table-border: #374151;
 }
 
+/* Explicit light mode overrides to counter system dark preference */
+.light {
+  --background: #ffffff;
+  --foreground: #171717;
+  --card-bg: #ffffff;
+  --text-muted: #4b5563;
+  --table-border: #e5e7eb;
+}
+
 /* ===========================
    🌟 GLOBAL STYLES
 =========================== */


### PR DESCRIPTION
## Summary
- ensure light mode overrides dark preference

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688a2697e3c8832482310e22f175a090